### PR TITLE
Update workflow dispatch #GTM-264

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    if: github.event.deployment_status.state == 'success'
+    if: ${{ github.event.deployment_status.state == 'success' || github.event.name == 'workflow_dispatch' }}
     steps:
       - name: Get PR Number
         uses: actions/github-script@v6

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Tests
-        uses: replayio/action-playwright@v0.4.10
+        uses: replayio/action-playwright@v0.4.12
         with:
           project: ${{ github.event.inputs.project || 'replay-firefox' }}
           issue-number: ${{ steps.pr-number.outputs.result }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Run Tests
         uses: replayio/action-playwright@v0.4.10
         with:
-          project: ${{ github.event.inputs.project || 'firefox' }}
+          project: ${{ github.event.inputs.project || 'replay-firefox' }}
           issue-number: ${{ steps.pr-number.outputs.result }}
           apiKey: ${{ secrets.REPLAYWORKSPACEAPIKEY }}
         env:
           RECORD_REPLAY_DONT_RECORD: ${{ github.event.inputs.doNotRecord && '1'}}
-          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url || 'https://www.gotbugs.io/' }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url || 'https://www.replayable.dev/' }}


### PR DESCRIPTION
updates workflow file so test job is not skipped when there is no deployment status, also makes replay-firefox the default so we can record tests.