### PR TITLE
fixes typo in event_name

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Tests
-        uses: replayio/action-playwright@v0.4.12
+        uses: replayio/action-playwright@v0.4.10
         with:
           project: ${{ github.event.inputs.project || 'replay-firefox' }}
           issue-number: ${{ steps.pr-number.outputs.result }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    if: ${{ github.event.deployment_status.state == 'success' || github.event.name == 'workflow_dispatch' }}
+    if: github.event.deployment_status.state == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Get PR Number
         uses: actions/github-script@v6


### PR DESCRIPTION
There's no way to test the manual workflow_dispatch until merged, so hopefully this resolves. Also found docs that you can remove the expression syntax in the `if`, so removed that as well.